### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,6 +5,8 @@
 # For more see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Adam-Robson/reduction/security/code-scanning/1](https://github.com/Adam-Robson/reduction/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Since the workflow only checks out the repository, sets up Node.js, installs dependencies, and runs tests, it only needs `contents: read` permission. This ensures that the `GITHUB_TOKEN` is restricted to read-only access to the repository contents.

The `permissions` block will be added after the `name` field (line 7) to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
